### PR TITLE
[Fix] 상점 페이지 아이템 희귀도별로 섹션 분리

### DIFF
--- a/BJJ_iOS/BJJ_iOS.xcodeproj/project.pbxproj
+++ b/BJJ_iOS/BJJ_iOS.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		3FE53C122DE1A1F500FBA99E /* MenuReviewListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE53C112DE1A1F500FBA99E /* MenuReviewListCell.swift */; };
 		3FEDD49F2CB2B3A8009617A5 /* PretendardKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3FEDD49E2CB2B3A8009617A5 /* PretendardKit */; };
 		3FEDD4A12CB2B499009617A5 /* UIColor++Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEDD4A02CB2B499009617A5 /* UIColor++Extensions.swift */; };
+		3FF1C3BC2DE84D91002E8CD8 /* ItemSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1C3BB2DE84D91002E8CD8 /* ItemSectionHeaderView.swift */; };
 		3FF1E92A2D66F9A300A237FA /* ReviewContentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1E9292D66F9A300A237FA /* ReviewContentCell.swift */; };
 		3FF1E92C2D67067000A237FA /* UITextView++Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1E92B2D67067000A237FA /* UITextView++Extensions.swift */; };
 		3FF6CAC32D50A544006ED4F3 /* MyReviewFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF6CAC22D50A544006ED4F3 /* MyReviewFooterView.swift */; };
@@ -328,6 +329,7 @@
 		3FE186312D9FCB650086EC6C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		3FE53C112DE1A1F500FBA99E /* MenuReviewListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuReviewListCell.swift; sourceTree = "<group>"; };
 		3FEDD4A02CB2B499009617A5 /* UIColor++Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor++Extensions.swift"; sourceTree = "<group>"; };
+		3FF1C3BB2DE84D91002E8CD8 /* ItemSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemSectionHeaderView.swift; sourceTree = "<group>"; };
 		3FF1E9292D66F9A300A237FA /* ReviewContentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewContentCell.swift; sourceTree = "<group>"; };
 		3FF1E92B2D67067000A237FA /* UITextView++Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView++Extensions.swift"; sourceTree = "<group>"; };
 		3FF6CAC22D50A544006ED4F3 /* MyReviewFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReviewFooterView.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 			isa = PBXGroup;
 			children = (
 				3F1472482DACF90D00098C41 /* ItemTypeCell.swift */,
+				3FF1C3BB2DE84D91002E8CD8 /* ItemSectionHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1878,6 +1881,7 @@
 				3FE186322D9FCB650086EC6C /* LoginViewController.swift in Sources */,
 				3F2BE79C2D50F687005003CC /* MyReviewDetailView.swift in Sources */,
 				3FC123292DA5245100676A09 /* MemberModel.swift in Sources */,
+				3FF1C3BC2DE84D91002E8CD8 /* ItemSectionHeaderView.swift in Sources */,
 				3F14723F2DACEF5900098C41 /* StoreModel.swift in Sources */,
 				3F61252F2DA6ABB6003B5851 /* MyPageAddress.swift in Sources */,
 				3FA1D3232D7EDAAB00010931 /* MyReviewImageDetailViewController.swift in Sources */,

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/Model/GachaResultSection.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/Model/GachaResultSection.swift
@@ -10,4 +10,5 @@ import Foundation
 struct GachaResultSection: Hashable {
     let itemID: Int
     let itemType: String
+    let itemRarity: String
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
@@ -132,7 +132,13 @@ final class GachaResultViewController: UIViewController {
     }
     
     @objc private func dismissModal() {
-        NotificationCenter.default.post(name: .didDismissFromGachaResultVC, object: drawnItemInfo?.itemID)
+        if let itemID = drawnItemInfo?.itemID,
+           let itemRarity = drawnItemInfo?.itemRarity {
+            NotificationCenter.default.post(
+                name: .didDismissFromGachaResultVC,
+                object: (itemRarity, itemID)
+            )
+        }
         self.presentingViewController?.presentingViewController?.dismiss(animated: true)
     }
     
@@ -143,7 +149,11 @@ final class GachaResultViewController: UIViewController {
         GachaResultAPI.postItemGacha(itemType: itemType) { result in
             switch result {
             case .success(let itemInfo):
-                self.drawnItemInfo = GachaResultSection(itemID: itemInfo.itemID, itemType: itemInfo.itemType)
+                self.drawnItemInfo = GachaResultSection(
+                                        itemID: itemInfo.itemID,
+                                        itemType: itemInfo.itemType,
+                                        itemRarity: itemInfo.itemRarity
+                                     )
                 completion(itemInfo)
                 
             case .failure(let error):

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/Model/StoreSection.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/Model/StoreSection.swift
@@ -17,3 +17,20 @@ struct StoreSection: Hashable {
     let isWearing: Bool
     let isOwned: Bool
 }
+
+enum ItemRarity: String {
+    case common = "COMMON"
+    case normal = "NORMAL"
+    case rare = "RARE"
+
+    var koreanTitle: String {
+        switch self {
+        case .common: 
+            return "흔함"
+        case .normal: 
+            return "보통"
+        case .rare: 
+            return "희귀"
+        }
+    }
+}

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/View/ItemSectionHeaderView.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/View/ItemSectionHeaderView.swift
@@ -1,0 +1,67 @@
+//
+//  ItemSectionHeaderView.swift
+//  BJJ_iOS
+//
+//  Created by HyoTaek on 5/29/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ItemSectionHeaderView: UICollectionReusableView, ReuseIdentifying {
+    
+    // MARK: - UI Components
+    
+    private let testItemRarityBackgroundView = UIView().then {
+        $0.backgroundColor = .customColor(.subColor)
+    }
+    
+    private let testItemRarityLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_bold, size: 15, color: .black)
+    }
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setAddView()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Set AddView
+    
+    private func setAddView() {
+        [
+            testItemRarityBackgroundView
+        ].forEach(addSubview)
+        
+        [
+            testItemRarityLabel
+        ].forEach(testItemRarityBackgroundView.addSubview)
+    }
+    
+    // MARK: - Set Constraints
+    
+    private func setConstraints() {
+        testItemRarityBackgroundView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(130)
+        }
+        
+        testItemRarityLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Set UI
+    
+    func setUI(itemRarity: String) {
+        testItemRarityLabel.text = itemRarity
+    }
+}

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewController/StoreViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewController/StoreViewController.swift
@@ -31,7 +31,7 @@ final class StoreViewController: UIViewController {
     
     private lazy var testAllItemCollectionView = UICollectionView(
         frame: .zero,
-        collectionViewLayout: createFlowLayout()
+        collectionViewLayout: createCompositionalLayout()
     ).then {
         $0.register(ItemTypeCell.self, forCellWithReuseIdentifier: ItemTypeCell.reuseIdentifier)
         $0.delegate = self
@@ -123,13 +123,34 @@ final class StoreViewController: UIViewController {
     
     // MARK: - Create Layout
     
-    private func createFlowLayout() -> UICollectionViewFlowLayout {
-        let layout = UICollectionViewFlowLayout()
-        
-        layout.scrollDirection = .vertical
-        layout.minimumLineSpacing = 20
+    private func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { sectionIndex, environment in
+            // 아이템 설정
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(0.2),
+                heightDimension: .absolute(100)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            
+            // 그룹 설정
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(100)
+            )
+            let group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: groupSize,
+                subitem: item,
+                count: 4
+            )
+            group.interItemSpacing = .fixed(10)
+            
+            // 섹션 설정
+            let section = NSCollectionLayoutSection(group: group)
+            section.contentInsets = NSDirectionalEdgeInsets(top: .zero, leading: .zero, bottom: 80, trailing: .zero)
+            section.orthogonalScrollingBehavior = .none
 
-        return layout
+            return section
+        }
     }
     
     // MARK: - Objc Functions
@@ -238,10 +259,6 @@ extension StoreViewController: UICollectionViewDataSource, UICollectionViewDeleg
         }
         
         return cell
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.frame.width / 5, height: 100)
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {


### PR DESCRIPTION
# 📌 이슈번호
- #93 

# 📌 구현/추가 사항
- 아이템 희귀도별로 섹션 분리하기 위해 ordered dictionary 도입
- 섹션별로 헤더 추가 및 한글 타이틀 추가
- 뽑힌 아이템의 UI만 새로고침하는 로직으로 변경

# 📷 미리보기
https://github.com/user-attachments/assets/70472b08-410f-4a9f-bf14-2aa1313be437