### PR TITLE
[Fix] 메뉴 상세페이지 플로우 수정

### DIFF
--- a/BJJ_iOS/BJJ_iOS/Source/Extensions/UITextView++Extensions.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Extensions/UITextView++Extensions.swift
@@ -14,4 +14,26 @@ extension UITextView {
         self.font = .customFont(font, size)
         self.text = text
     }
+    
+    func numberOfLines() -> Int {
+        // TODO: 현재는 textKit1 적용중. 추후에는 iOS 16이상부턴 textKit2 적용하기
+        
+        let layoutManager = self.layoutManager
+        var line = 0, glyph = 0, range = NSRange()
+
+        // maximumNumberOfLines 임시 해제
+        let originalMax = self.textContainer.maximumNumberOfLines
+        
+        self.textContainer.maximumNumberOfLines = 0
+        layoutManager.ensureLayout(for: self.textContainer)
+
+        while glyph < layoutManager.numberOfGlyphs {
+            layoutManager.lineFragmentUsedRect(forGlyphAt: glyph, effectiveRange: &range)
+            glyph = NSMaxRange(range)
+            line += 1
+        }
+        self.textContainer.maximumNumberOfLines = originalMax
+        
+        return line
+    }
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewInfoView.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewInfoView.swift
@@ -18,9 +18,6 @@ final class MenuReviewInfoView: UIView {
     private var reviewLikedCount = 0
     var onLikeToggled: ((Bool) -> Void)?
     
-    // TODO: onReportReview 삭제
-    var onReportReview: (() -> Void)?
-    
     // MARK: - UI Components
     
     private let profileImage = UIImageView().then {
@@ -37,12 +34,6 @@ final class MenuReviewInfoView: UIView {
     
     private let reviewDateLabel = UILabel().then {
         $0.setLabelUI("", font: .pretendard, size: 13, color: .darkGray)
-    }
-    
-    // TODO: reportReviewButton 삭제
-    private lazy var reportReviewButton = UIButton().then {
-        $0.setImage(UIImage(named: "Notice")?.resize(to: CGSize(width: 20, height: 20)), for: .normal)
-        $0.addTarget(self, action: #selector(didTapReportReviewButton), for: .touchUpInside)
     }
     
     private lazy var reviewLikeButton = UIButton().then {
@@ -92,8 +83,6 @@ final class MenuReviewInfoView: UIView {
             nicknameLabel,
             reviewRatingView,
             reviewDateLabel,
-            // TODO: reportReviewButton 삭제
-            reportReviewButton,
             reviewLikeButton,
             reviewLikeCountLabel
         ].forEach(addSubview)
@@ -120,12 +109,6 @@ final class MenuReviewInfoView: UIView {
         reviewDateLabel.snp.makeConstraints {
             $0.leading.equalTo(reviewRatingView.snp.trailing).offset(10)
             $0.centerY.equalTo(reviewRatingView)
-        }
-        
-        // TODO: reportReviewButton 삭제
-        reportReviewButton.snp.makeConstraints {
-            $0.top.equalTo(profileImage)
-            $0.leading.equalTo(reviewDateLabel.snp.trailing).offset(50)
         }
         
         reviewLikeButton.snp.makeConstraints {
@@ -190,10 +173,5 @@ final class MenuReviewInfoView: UIView {
             // TODO: 실패 UI 띄우기
             print("[MenuReviewInfoView] Error: 자기 리뷰 좋아요 안됨")
         }
-    }
-    
-    // TODO: 삭제
-    @objc private func didTapReportReviewButton() {
-        onReportReview?()
     }
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -22,6 +22,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     
     var onTapReviewMoreButton: (() -> Void)?
     var onTapReview: (() -> Void)?
+    var onTapReviewImage: (() -> Void)?
     
     // MARK: - UI Components
     
@@ -58,6 +59,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     ).then {
         $0.register(MenuReviewImageCell.self, forCellWithReuseIdentifier: MenuReviewImageCell.reuseIdentifier)
         $0.dataSource = self
+        $0.delegate = self
         $0.showsHorizontalScrollIndicator = false
         $0.alwaysBounceVertical = false
     }
@@ -272,6 +274,8 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     }
 }
 
+// MARK: - UICollectionView DataSource
+
 extension MenuReviewListCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if collectionView == reviewImageCollectionView {
@@ -308,6 +312,14 @@ extension MenuReviewListCell: UICollectionViewDataSource {
             )
             return cell
         }
+    }
+}
+
+// MARK: - UICollectionView Delegate
+
+extension MenuReviewListCell: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        onTapReviewImage?()
     }
 }
 

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -173,6 +173,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         )
         menuReviewInfoView.setUI(with: menuReview)
         reviewCommentTextView.text = menuReview.reviewComment
+        setReviewMoreButtonVisibility()
         reviewImageCollectionView.setCollectionViewLayout(flowLayout, animated: false)
         
         if reviewImageCount == 0 {
@@ -272,5 +273,20 @@ extension MenuReviewListCell: UICollectionViewDataSource {
             )
             return cell
         }
+    }
+}
+
+// MARK: Update ReviewMoreButton Hidden
+
+extension MenuReviewListCell {
+    private func setReviewMoreButtonVisibility() {
+        reviewCommentTextView.layoutIfNeeded()
+        let lines = reviewCommentTextView.numberOfLines()
+        
+        reviewTextMoreButton.isHidden = lines <= 3
+        reviewStackView.setCustomSpacing(
+            reviewTextMoreButton.isHidden ? 12 : 0,
+            after: reviewCommentTextView
+        )
     }
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -28,10 +28,14 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     // TODO: private 해제 방법 말고 다른 방법 없을까?
     let menuReviewInfoView = MenuReviewInfoView()
     
-    private let reviewCommentLabel = UILabel().then {
-        $0.setLabelUI("", font: .pretendard_medium, size: 13, color: .black)
-        $0.numberOfLines = 0
-        $0.lineBreakMode = .byWordWrapping
+    private let reviewCommentTextView = UITextView().then {
+        $0.setTextViewUI("", font: .pretendard_medium, size: 13, color: .black)
+        $0.textContainer.lineBreakMode = .byTruncatingTail
+        $0.textContainer.maximumNumberOfLines = 3
+        $0.isEditable = false
+        $0.isScrollEnabled = false
+        $0.textContainerInset = .zero
+        $0.textContainer.lineFragmentPadding = 0
     }
     
     private lazy var reviewImageCollectionView = UICollectionView(
@@ -88,7 +92,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
             $0.height.equalTo(25)
         }
         
-        reviewCommentLabel.text = ""
+        reviewCommentTextView.text = ""
         menuReviewInfoView.resetUI()
     }
     
@@ -108,7 +112,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         
         [
             menuReviewInfoView,
-            reviewCommentLabel,
+            reviewCommentTextView,
             reviewImageCollectionView,
             reviewHashTagCollectionView
         ].forEach(reviewStackView.addArrangedSubview)
@@ -129,7 +133,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
             $0.height.equalTo(41)
         }
         
-        reviewCommentLabel.snp.makeConstraints {
+        reviewCommentTextView.snp.makeConstraints {
             $0.width.equalToSuperview()
         }
         
@@ -163,7 +167,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
             reviewLikedCount: menuReview.reviewLikedCount
         )
         menuReviewInfoView.setUI(with: menuReview)
-        reviewCommentLabel.text = menuReview.reviewComment
+        reviewCommentTextView.text = menuReview.reviewComment
         reviewImageCollectionView.setCollectionViewLayout(flowLayout, animated: false)
         
         if reviewImageCount == 0 {

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -22,7 +22,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     private let reviewStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 12
-        $0.alignment = .leading
+        $0.alignment = .trailing
     }
     
     // TODO: private 해제 방법 말고 다른 방법 없을까?
@@ -36,6 +36,10 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         $0.isScrollEnabled = false
         $0.textContainerInset = .zero
         $0.textContainer.lineFragmentPadding = 0
+    }
+    
+    private lazy var reviewTextMoreButton = UILabel().then {
+        $0.setLabelUI("더보기", font: .pretendard_medium, size: 13, color: .midGray)
     }
     
     private lazy var reviewImageCollectionView = UICollectionView(
@@ -69,6 +73,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         setUI()
         setAddView()
         setConstraints()
+        setStackView()
     }
     
     required init?(coder: NSCoder) {
@@ -113,6 +118,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         [
             menuReviewInfoView,
             reviewCommentTextView,
+            reviewTextMoreButton,
             reviewImageCollectionView,
             reviewHashTagCollectionView
         ].forEach(reviewStackView.addArrangedSubview)
@@ -151,6 +157,12 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
             $0.width.bottom.equalToSuperview()
             $0.height.equalTo(7)
         }
+    }
+    
+    // MARK: - Set StackView
+    
+    private func setStackView() {
+        reviewStackView.setCustomSpacing(0, after: reviewCommentTextView)
     }
     
     // MARK: - Configure Cell

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -16,6 +16,10 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     private var reviewImages: [String] = []
     private var hashTags: [String] = []
     private var isHashTagsHighlighted: [Bool] = []
+    
+    private var isReviewExpanded = false
+    private var isOver3LineReview = false
+    
     var onTapReviewMoreButton: (() -> Void)?
     
     // MARK: - UI Components
@@ -176,6 +180,9 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         )
         menuReviewInfoView.setUI(with: menuReview)
         reviewCommentTextView.text = menuReview.reviewComment
+        if !isOver3LineReview {
+            isOver3LineReview = reviewCommentTextView.numberOfLines() > 3
+        }
         setReviewMoreButtonVisibility()
         reviewImageCollectionView.setCollectionViewLayout(flowLayout, animated: false)
         
@@ -199,8 +206,11 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     // MARK: - objc Functions
     
     @objc private func didTapReviewMoreButton() {
-        reviewCommentTextView.textContainer.maximumNumberOfLines = 0
-        reviewCommentTextView.textContainer.lineBreakMode = .byCharWrapping
+        isReviewExpanded.toggle()
+        
+        reviewTextMoreButton.text = isReviewExpanded ? "접기" : "더보기"
+        reviewCommentTextView.textContainer.maximumNumberOfLines =  isReviewExpanded ? 0 : 3
+        reviewCommentTextView.textContainer.lineBreakMode = isReviewExpanded ? .byCharWrapping : .byTruncatingTail
         reviewCommentTextView.invalidateIntrinsicContentSize()
         
         self.setNeedsLayout()
@@ -297,9 +307,7 @@ extension MenuReviewListCell: UICollectionViewDataSource {
 extension MenuReviewListCell {
     private func setReviewMoreButtonVisibility() {
         reviewCommentTextView.layoutIfNeeded()
-        let lines = reviewCommentTextView.numberOfLines()
-        
-        reviewTextMoreButton.isHidden = lines <= 3
+        reviewTextMoreButton.isHidden = !(isOver3LineReview)
         reviewStackView.setCustomSpacing(
             reviewTextMoreButton.isHidden ? 12 : 0,
             after: reviewCommentTextView

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -16,6 +16,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     private var reviewImages: [String] = []
     private var hashTags: [String] = []
     private var isHashTagsHighlighted: [Bool] = []
+    var onTapReviewMoreButton: (() -> Void)?
     
     // MARK: - UI Components
     
@@ -40,6 +41,8 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     
     private lazy var reviewTextMoreButton = UILabel().then {
         $0.setLabelUI("더보기", font: .pretendard_medium, size: 13, color: .midGray)
+        $0.isUserInteractionEnabled = true
+        $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapReviewMoreButton)))
     }
     
     private lazy var reviewImageCollectionView = UICollectionView(
@@ -191,6 +194,19 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         DispatchQueue.main.async {
             self.reviewImageCollectionView.reloadData()
         }
+    }
+    
+    // MARK: - objc Functions
+    
+    @objc private func didTapReviewMoreButton() {
+        reviewCommentTextView.textContainer.maximumNumberOfLines = 0
+        reviewCommentTextView.textContainer.lineBreakMode = .byCharWrapping
+        reviewCommentTextView.invalidateIntrinsicContentSize()
+        
+        self.setNeedsLayout()
+        self.layoutIfNeeded()
+        
+        onTapReviewMoreButton?()
     }
     
     func bindHashTagData(hashTags: [String], isHighlighted: [Bool]) {

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -21,13 +21,15 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     private var isOver3LineReview = false
     
     var onTapReviewMoreButton: (() -> Void)?
+    var onTapReview: (() -> Void)?
     
     // MARK: - UI Components
     
-    private let reviewStackView = UIStackView().then {
+    private lazy var reviewStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 12
         $0.alignment = .trailing
+        $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapReview)))
     }
     
     // TODO: private 해제 방법 말고 다른 방법 없을까?
@@ -204,6 +206,10 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
     }
     
     // MARK: - objc Functions
+    
+    @objc private func didTapReview() {
+        onTapReview?()
+    }
     
     @objc private func didTapReviewMoreButton() {
         isReviewExpanded.toggle()

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -30,7 +30,10 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         $0.axis = .vertical
         $0.spacing = 12
         $0.alignment = .trailing
-        $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapReview)))
+        $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapReview)).then {
+            $0.delegate = self
+            $0.cancelsTouchesInView = false
+        })
     }
     
     // TODO: private 해제 방법 말고 다른 방법 없을까?
@@ -320,6 +323,19 @@ extension MenuReviewListCell: UICollectionViewDataSource {
 extension MenuReviewListCell: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         onTapReviewImage?()
+    }
+}
+
+// MARK: - UIGestureRecognizer Delegate
+
+extension MenuReviewListCell: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ g: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        
+        // 터치된 뷰가 reviewImageCollectionView의 subView라면 gesture 비활성화
+        if let touchedView = touch.view,
+           touchedView.isDescendant(of: reviewImageCollectionView) { return false }
+        
+        return true
     }
 }
 

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -226,6 +226,8 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         onTapReviewMoreButton?()
     }
     
+    // MARK: - Bind Hashtag Data
+    
     func bindHashTagData(hashTags: [String], isHighlighted: [Bool]) {
         self.hashTags = hashTags
         self.isHashTagsHighlighted = isHighlighted

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -73,7 +73,6 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         setUI()
         setAddView()
         setConstraints()
-        setStackView()
     }
     
     required init?(coder: NSCoder) {
@@ -157,12 +156,6 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
             $0.width.bottom.equalToSuperview()
             $0.height.equalTo(7)
         }
-    }
-    
-    // MARK: - Set StackView
-    
-    private func setStackView() {
-        reviewStackView.setCustomSpacing(0, after: reviewCommentTextView)
     }
     
     // MARK: - Configure Cell

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -39,6 +39,7 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         $0.setTextViewUI("", font: .pretendard_medium, size: 13, color: .black)
         $0.textContainer.lineBreakMode = .byTruncatingTail
         $0.textContainer.maximumNumberOfLines = 3
+        $0.isUserInteractionEnabled = false
         $0.isEditable = false
         $0.isScrollEnabled = false
         $0.textContainerInset = .zero

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
@@ -625,6 +625,13 @@ extension MenuDetailViewController: UICollectionViewDelegate, UICollectionViewDa
             
             cell.configure(with: reviewData[indexPath.item])
             cell.bindHashTagData(hashTags: hashTags, isHighlighted: isHighlighted)
+            cell.onTapReview = { [weak self] in
+                guard let self = self else { return }
+                
+                DispatchQueue.main.async {
+                    self.presentMyReviewDetailViewController(reviewID: self.reviewData[indexPath.item].reviewID)
+                }
+            }
             cell.onTapReviewMoreButton = { [weak collectionView] in
                 guard let collectionView = collectionView else { return }
                 

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
@@ -625,6 +625,15 @@ extension MenuDetailViewController: UICollectionViewDelegate, UICollectionViewDa
             
             cell.configure(with: reviewData[indexPath.item])
             cell.bindHashTagData(hashTags: hashTags, isHighlighted: isHighlighted)
+            cell.onTapReviewMoreButton = { [weak collectionView] in
+                guard let collectionView = collectionView else { return }
+                
+                UIView.performWithoutAnimation {
+                    collectionView.performBatchUpdates({
+                        collectionView.reloadItems(at: [indexPath])
+                    })
+                }
+            }
             cell.menuReviewInfoView.onLikeToggled = { [weak self] isLiked in
                 guard let self = self else { return }
                 

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
@@ -639,6 +639,13 @@ extension MenuDetailViewController: UICollectionViewDelegate, UICollectionViewDa
                     self.presentMyReviewDetailViewController(reviewID: self.reviewData[indexPath.item].reviewID)
                 }
             }
+            cell.onTapReviewImage = { [weak self] in
+                guard let self = self else { return }
+                
+                DispatchQueue.main.async {
+                    self.presentMyReviewImageDetailViewController(with: self.reviewData[indexPath.item].reviewImage ?? [])
+                }
+            }
             cell.onTapReviewMoreButton = { [weak collectionView] in
                 guard let collectionView = collectionView else { return }
                 

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
@@ -647,11 +647,6 @@ extension MenuDetailViewController: UICollectionViewDelegate, UICollectionViewDa
                 // 각 리뷰별 타이머 저장
                 self.reviewLikeDebounceTimers[indexPath.item] = timer
             }
-            cell.menuReviewInfoView.onReportReview = {
-                let reviewID = self.reviewData[indexPath.item].reviewID
-                
-                self.presentReportReviewViewController(reviewID: reviewID)
-            }
             
             return cell
         }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
@@ -166,6 +166,13 @@ final class MenuDetailViewController: UIViewController {
         )
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        // 네비바 숨김 상태 복구
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 


### PR DESCRIPTION
# 📌 이슈번호
- #144 

# 📌 구현/추가 사항
- 리뷰 누를 경우 리뷰 상세페이지로 이동
- 리뷰 사진 누를 경우 리뷰 사진 상세페이지로 이동
- 리뷰 신고 버튼 삭제 (리뷰 상세 페이지로 이동)
- 리뷰 텍스트가 4줄 이상일 경우 펼치기 / 접기 버튼 생성

# 📷 미리보기
https://github.com/user-attachments/assets/dd3865ea-01b8-4f06-a79f-18ba314fd25d