### PR TITLE
[New Feature] 뽑기 API 연동 및 상호작용

### DIFF
--- a/BJJ_iOS/BJJ_iOS.xcodeproj/project.pbxproj
+++ b/BJJ_iOS/BJJ_iOS.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		3F4B09252CE1FC31005C56C2 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B09242CE1FC31005C56C2 /* TabBarController.swift */; };
 		3F4DF56A2DF8197A006E047E /* ReviewPhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4DF5692DF8197A006E047E /* ReviewPhotoCell.swift */; };
 		3F5617B82CF3312400B4912D /* MenuReviewImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5617B72CF3312400B4912D /* MenuReviewImageCell.swift */; };
+		3F5F5E562F1F94C9001A8E99 /* Notification.Name++Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5F5E552F1F94C9001A8E99 /* Notification.Name++Extensions.swift */; };
 		3F5F842B2F1E3FE40029F4BE /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = 3F5F842A2F1E3FE40029F4BE /* RxDataSources */; };
 		3F5F842D2F1E40830029F4BE /* StoreSectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5F842C2F1E40830029F4BE /* StoreSectionModel.swift */; };
 		3F5F843B2F1E4D160029F4BE /* DateFormatterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5F843A2F1E4D160029F4BE /* DateFormatterManager.swift */; };
@@ -311,6 +312,7 @@
 		3F4B09242CE1FC31005C56C2 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		3F4DF5692DF8197A006E047E /* ReviewPhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPhotoCell.swift; sourceTree = "<group>"; };
 		3F5617B72CF3312400B4912D /* MenuReviewImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuReviewImageCell.swift; sourceTree = "<group>"; };
+		3F5F5E552F1F94C9001A8E99 /* Notification.Name++Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name++Extensions.swift"; sourceTree = "<group>"; };
 		3F5F842C2F1E40830029F4BE /* StoreSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSectionModel.swift; sourceTree = "<group>"; };
 		3F5F843A2F1E4D160029F4BE /* DateFormatterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterManager.swift; sourceTree = "<group>"; };
 		3F6125282DA6A80E003B5851 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
@@ -731,6 +733,7 @@
 				3FF1E92B2D67067000A237FA /* UITextView++Extensions.swift */,
 				3F90699D2F15391F00FDBC94 /* UIImageView++Extensions.swift */,
 				3F9A5F2F2F16250F00AB0576 /* UITextField++Extensions.swift */,
+				3F5F5E552F1F94C9001A8E99 /* Notification.Name++Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2187,6 +2190,7 @@
 				3F1472412DACEF6300098C41 /* StoreAddress.swift in Sources */,
 				3F4831F02D89831700B138A2 /* ReviewModalSection.swift in Sources */,
 				3F31AAE32D675C5700FDCC35 /* ReviewAddPhoto.swift in Sources */,
+				3F5F5E562F1F94C9001A8E99 /* Notification.Name++Extensions.swift in Sources */,
 				3F375BAA2D577323005015C1 /* ReviewCategorySelect.swift in Sources */,
 				3F8D58DA2D787936009356AE /* NoticeView.swift in Sources */,
 				3FCF9B082D803C8E00FB8252 /* ReviewWriteCollectionViewLayout.swift in Sources */,

--- a/BJJ_iOS/BJJ_iOS/Source/Extensions/Notification.Name++Extensions.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Extensions/Notification.Name++Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  Notification.Name++Extensions.swift
+//  BJJ_iOS
+//
+//  Created by HyoTaek on 1/20/26.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let itemValidPeriodRefresh = Notification.Name("itemValidPeriodRefresh")
+}

--- a/BJJ_iOS/BJJ_iOS/Source/Extensions/UIViewController++Extensions.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Extensions/UIViewController++Extensions.swift
@@ -196,8 +196,8 @@ extension UIViewController {
     }
     
     /// GachaVC로 push
-    func presentGachaViewController() {
-        let gachaVC = GachaViewController()
+    func presentGachaViewController(itemType: ItemType) {
+        let gachaVC = GachaViewController(itemType: itemType)
         
         gachaVC.modalPresentationStyle = .overFullScreen
         present(gachaVC, animated: true)

--- a/BJJ_iOS/BJJ_iOS/Source/Manager/DateFormatterManager.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Manager/DateFormatterManager.swift
@@ -23,11 +23,11 @@ final class DateFormatterManager {
     }
     
     /// 아이템 유효기간 파싱용 포맷터 (재사용)
-    /// 형식: "yyyy-MM-dd'T'HH:mm:ss"
+    /// 형식: "yyyy-MM-dd'T'HH:mm:ss.SSSSSS" (마이크로초 포함)
     private let itemValidPeriodFormatter = DateFormatter().then {
         $0.locale = Locale(identifier: "ko_KR")
         $0.timeZone = TimeZone(identifier: "Asia/Seoul")
-        $0.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        $0.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
     }
     
     /// Calendar 인스턴스 (재사용)
@@ -57,7 +57,7 @@ final class DateFormatterManager {
     }
 
     /// 아이템 유효기간 계산
-    /// - Parameter dateString: 유효기간 날짜 문자열 (형식: "yyyy-MM-dd'T'HH:mm:ss")
+    /// - Parameter dateString: 유효기간 날짜 문자열 (형식: "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
     /// - Returns: 남은 기간 문자열 (d/h/m 형식) 또는 nil (파싱 실패 시)
     func calculateItemValidPeriod(from dateString: String) -> String? {
         guard let validDate = itemValidPeriodFormatter.date(from: dateString) else {

--- a/BJJ_iOS/BJJ_iOS/Source/Network/API/MyPage/GachaResult/Model/GachaResultModel.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Network/API/MyPage/GachaResult/Model/GachaResultModel.swift
@@ -18,12 +18,12 @@ struct GachaResultModel: Codable {
     let isOwned: Bool
     
     enum CodingKeys: String, CodingKey {
-        case itemID = "itemId"
+        case itemID = "itemIdx"
         case itemName
         case itemType
         case itemRarity = "itemLevel"
         case itemImage = "imageName"
-        case validPeriod
+        case validPeriod = "expiresAt"
         case isWearing
         case isOwned
     }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Gacha/ViewController/GachaViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Gacha/ViewController/GachaViewController.swift
@@ -18,6 +18,7 @@ final class GachaViewController: BaseViewController {
     private let backgroundTapGesture = UITapGestureRecognizer().then {
         $0.cancelsTouchesInView = false
     }
+    private let itemType: ItemType
     
     // MARK: - UI Components
     
@@ -27,7 +28,7 @@ final class GachaViewController: BaseViewController {
     }
     
     private let gachaTitleLabel = UILabel().then {
-        $0.setLabelUI("캐릭터 뽑기", font: .pretendard_bold, size: 18, color: .black)
+        $0.setLabelUI("", font: .pretendard_bold, size: 18, color: .black)
     }
     
     private let gachaGuideLabel = UILabel().then {
@@ -53,6 +54,19 @@ final class GachaViewController: BaseViewController {
         )
         $0.setCornerRadius(radius: 5)
         $0.addTarget(self, action: #selector(didTapGachaButton), for: .touchUpInside)
+    }
+    
+    // MARK: - Init
+    
+    init(itemType: ItemType) {
+        self.itemType = itemType
+        gachaTitleLabel.text = itemType == .character ? "캐릭터 뽑기" : "배경 뽑기"
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - Set UI

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Gacha/ViewController/GachaViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Gacha/ViewController/GachaViewController.swift
@@ -32,36 +32,21 @@ final class GachaViewController: BaseViewController {
     }
     
     private let gachaGuideLabel = UILabel().then {
-        $0.setLabel(
-            "뽑기를 해서 랜덤으로 캐릭터를 얻어요.\n뽑은 캐릭터는 7일의 유효기간이 있어요.",
-            font: .pretendard_medium,
-            size: 13,
-            color: ._999999
-        )
+        $0.setLabel("", font: .pretendard_medium, size: 13, color: ._999999)
         $0.numberOfLines = 2
         $0.textAlignment = .center
     }
     
-    private lazy var gachaButton = UIButton().then {
-        $0.setButtonWithIcon(
-            title: "100",
-            font: .pretendard_medium,
-            size: 18,
-            textColor: .black,
-            icon: .point,
-            iconPadding: 7,
-            backgroundColor: .FFEB_62
-        )
+    private let gachaButton = UIButton().then {
         $0.setCornerRadius(radius: 5)
-        $0.addTarget(self, action: #selector(didTapGachaButton), for: .touchUpInside)
     }
     
     // MARK: - Init
     
     init(itemType: ItemType) {
         self.itemType = itemType
-        gachaTitleLabel.text = itemType == .character ? "캐릭터 뽑기" : "배경 뽑기"
         super.init(nibName: nil, bundle: nil)
+        configureUI(itemType: itemType)
     }
     
     @available(*, unavailable)
@@ -127,12 +112,31 @@ final class GachaViewController: BaseViewController {
                 }
             }
             .disposed(by: disposeBag)
+        
+        // 뽑기 버튼 탭
+        gachaButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.presentGachaResultViewController(itemType: owner.itemType)
+            }
+            .disposed(by: disposeBag)
     }
     
-    @objc private func didTapGachaButton() {
-        DispatchQueue.main.async {
-            // TODO: 상점 페이지에서 캐릭터, 배경 탭의 상태를 전달받기.
-            self.presentGachaResultViewController(itemType: .character)
-        }
+    // MARK: - Configure UI
+    
+    private func configureUI(itemType: ItemType) {
+        let firstGuideMessage = itemType == .character ? "캐릭터를" : "배경을"
+        let secondGuideMessage = itemType == .character ? "캐릭터는" : "배경은"
+        
+        gachaTitleLabel.text = itemType == .character ? "캐릭터 뽑기" : "배경 뽑기"
+        gachaGuideLabel.text = "뽑기를 해서 랜덤으로 \(firstGuideMessage) 얻어요.\n뽑은 \(secondGuideMessage) 7일의 유효기간이 있어요."
+        gachaButton.setButtonWithIcon(
+            title: itemType == .character ? "50" : "100",
+            font: .pretendard_medium,
+            size: 18,
+            textColor: .black,
+            icon: .point,
+            iconPadding: 7,
+            backgroundColor: .FFEB_62
+        )
     }
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
@@ -137,7 +137,9 @@ final class GachaResultViewController: BaseViewController {
         // 백버튼 탭
         backButton.rx.tap
             .bind(with: self) { owner, _ in
-                owner.presentingViewController?.presentingViewController?.dismiss(animated: true)
+                owner.presentingViewController?.presentingViewController?.dismiss(animated: true) {
+                    NotificationCenter.default.post(name: .itemValidPeriodRefresh, object: nil)
+                }
             }
             .disposed(by: disposeBag)
         

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
@@ -14,10 +14,6 @@ import RxCocoa
 
 final class GachaResultViewController: BaseViewController {
     
-    // MARK: - Properties
-    
-    private var drawnItemInfo: GachaResultSection?
-    
     // MARK: - ViewModel
     
     private let gachaResultViewModel: GachaResultViewModel
@@ -99,7 +95,7 @@ final class GachaResultViewController: BaseViewController {
         
         itemImageView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().offset(221.52)
+            $0.bottom.equalTo(gachaResultView.snp.top).offset(-153.89)
         }
         
         gachaResultView.snp.makeConstraints {
@@ -158,56 +154,40 @@ final class GachaResultViewController: BaseViewController {
                 owner.gachaDescriptionLabel.text = "뽑기를 해서 랜덤으로 \(itemTexts[0]) 얻어요.\n뽑은 \(itemTexts[1]) 7일의 유효기간이 있어요."
             })
             .disposed(by: disposeBag)
-    }
-    
-    // MARK: - Configure
-    
-    private func configure(_ itemInfo: GachaResultModel) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            guard let characterURL = URL(string: baseURL.characterImageURL + itemInfo.itemImage) else { return }
-            
-            self.itemImageView.sd_setImage(
-                with: characterURL,
-                placeholderImage: nil,
-                options: [.retryFailed, .continueInBackground]
-            ) { _, _, _, _ in
-                // TODO: 이미지 크기 변경
-                // 이미지 로드 완료 후 크기 확대
-                UIView.animate(withDuration: 0) {
-                    self.itemImageView.transform = CGAffineTransform(scaleX: 2.0, y: 2.0)
+        
+        // 아이템 이미지 URL 바인딩
+        output.itemImageURL
+            .drive(with: self, onNext: { owner, url in
+                guard let url = url else { return }
+                owner.itemImageView.sd_setImage(
+                    with: url,
+                    placeholderImage: nil,
+                    options: [.retryFailed, .continueInBackground]
+                ) { _, _, _, _ in
+                    // 이미지 로드 완료 후 크기 확대
+                    UIView.animate(withDuration: 0) {
+                        owner.itemImageView.transform = CGAffineTransform(scaleX: 2.0, y: 2.0)
+                    }
                 }
-            }
-            self.gachaResultTitleLabel.text = "\(itemInfo.itemName) 등장!"
-        }
-    }
-    
-    // MARK: - Post API
-    
-    // TODO: GachaResultModel말고 GachaResultSection사용할지 말지 고민
-    private func postItemGacha(itemType: String, completion: @escaping (_ itemInfo: GachaResultModel) -> Void) {
-        GachaResultAPI.postItemGacha(itemType: itemType) { result in
-            switch result {
-            case .success(let itemInfo):
-                self.drawnItemInfo = GachaResultSection(
-                                        itemID: itemInfo.itemID,
-                                        itemType: itemInfo.itemType,
-                                        itemRarity: itemInfo.itemRarity
-                                     )
-                completion(itemInfo)
-                
-            case .failure(let error):
-                print("[GachaResultVC] Error: \(error.localizedDescription)")
-            }
-        }
+            })
+            .disposed(by: disposeBag)
+        
+        // 아이템 타이틀 바인딩
+        output.itemTitle
+            .drive(gachaResultTitleLabel.rx.text)
+            .disposed(by: disposeBag)
     }
     
     // MARK: - Patch API
     
     private func patchItem() {
-        // TODO: 캐릭터인지 배경인지 구분해서 PATCH 요청 보내기
-        // TODO: itemType, itemID가 없을 경우 빈 문자열과 0 보내지 말고 다른 방법 고민하기
-        GachaResultAPI.patchItem(itemType: drawnItemInfo?.itemType ?? "", itemID: drawnItemInfo?.itemID ?? 0) { result in
+        // ViewModel에서 drawnItemInfo 가져오기
+        guard let drawnItemInfo = gachaResultViewModel.getDrawnItemInfo() else {
+            print("[GachaResultVC] Error: drawnItemInfo is nil")
+            return
+        }
+        
+        GachaResultAPI.patchItem(itemType: drawnItemInfo.itemType, itemID: drawnItemInfo.itemID) { result in
             switch result {
             case .success:
                 // TODO: 빈 응답이라도 보내줘야됨. 현재는 아무 응답도 받지 못해서 Empty로도 디코딩하지 못하는것.

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewController/GachaResultViewController.swift
@@ -46,13 +46,7 @@ final class GachaResultViewController: BaseViewController {
     }
     
     private let gachaDescriptionLabel = UILabel().then {
-        // TODO: 캐릭터/배경 모두 유효기간 7일. itemType에 따라 문구 수정
-        $0.setLabel(
-            "뽑기를 해서 랜덤으로 캐릭터를 얻어요.\n뽑은 캐릭터는 7일의 유효기간이 있어요.",
-            font: .pretendard_semibold,
-            size: 15,
-            color: ._999999
-        )
+        $0.setLabel("", font: .pretendard_semibold, size: 15, color: ._999999)
         $0.numberOfLines = 2
         $0.textAlignment = .center
     }
@@ -156,6 +150,13 @@ final class GachaResultViewController: BaseViewController {
             .bind(with: self) { owner, _ in
                 owner.patchItem()
             }
+            .disposed(by: disposeBag)
+        
+        // 뽑기 결과 설명 텍스트 설정
+        output.itemType
+            .bind(with: self, onNext: { owner, itemTexts in
+                owner.gachaDescriptionLabel.text = "뽑기를 해서 랜덤으로 \(itemTexts[0]) 얻어요.\n뽑은 \(itemTexts[1]) 7일의 유효기간이 있어요."
+            })
             .disposed(by: disposeBag)
     }
     

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewModel/GachaResultViewModel.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewModel/GachaResultViewModel.swift
@@ -5,14 +5,20 @@
 //  Created by HyoTaek on 1/20/26.
 //
 
+import Foundation
 import RxSwift
 import RxCocoa
 
 final class GachaResultViewModel: BaseViewModel {
     
+    // MARK: - DisposeBag
+    
+    private let disposeBag = DisposeBag()
+    
     // MARK: - Properties
     
     private let itemType: ItemType
+    private var drawnItemInfo: GachaResultSection?
     
     // MARK: - Init
     
@@ -30,15 +36,91 @@ final class GachaResultViewModel: BaseViewModel {
     
     struct Output {
         let itemType: BehaviorRelay<[String]>
+        let drawnItem: Driver<GachaResultModel>
+        let itemImageURL: Driver<URL?>
+        let itemTitle: Driver<String>
     }
     
     // MARK: - Transform
     
     func transform(input: Input) -> Output {
+        // viewDidLoad 시 뽑기 API 호출
+        let drawnItem = input.viewDidLoad
+            .flatMapLatest { [weak self] _ -> Observable<GachaResultModel> in
+                guard let self = self else {
+                    return Observable.empty()
+                }
+                return self.postItemGacha(itemType: self.itemType.rawValue)
+            }
+            .share(replay: 1)
+
+        // 이미지 URL 생성
+        let itemImageURL = drawnItem
+            .map { itemInfo -> URL? in
+                let baseURL = self.itemType == .character
+                                ? baseURL.characterImageURL + "gacha_"
+                                : baseURL.backgroundImageURL
+                return URL(string: baseURL + itemInfo.itemImage + ".svg")
+            }
+            .asDriver(onErrorJustReturn: nil)
+        
+        // 타이틀 텍스트 생성
+        let itemTitle = drawnItem
+            .map { itemInfo in
+                return "\(itemInfo.itemName) 등장!"
+            }
+            .asDriver(onErrorJustReturn: "")
+        
         return Output(
             itemType: BehaviorRelay(
                 value: itemType == .character ? ["캐릭터를", "캐릭터는"] : ["배경을", "배경은"]
-            )
+            ),
+            drawnItem: drawnItem.asDriver(onErrorJustReturn: GachaResultModel(
+                itemID: 0,
+                itemName: "",
+                itemType: "",
+                itemRarity: "",
+                itemImage: "",
+                validPeriod: nil,
+                isWearing: false,
+                isOwned: false
+            )),
+            itemImageURL: itemImageURL,
+            itemTitle: itemTitle
         )
+    }
+    
+    // MARK: - API Methods
+    
+    /// 뽑기 API 호출
+    private func postItemGacha(itemType: String) -> Observable<GachaResultModel> {
+        return Observable.create { [weak self] observer in
+            GachaResultAPI.postItemGacha(itemType: itemType) { result in
+                switch result {
+                case .success(let itemInfo):
+                    // drawnItemInfo 저장 (착용하기 API 호출 시 사용)
+                    self?.drawnItemInfo = GachaResultSection(
+                        itemID: itemInfo.itemID,
+                        itemType: itemInfo.itemType,
+                        itemRarity: itemInfo.itemRarity
+                    )
+                    observer.onNext(itemInfo)
+                    observer.onCompleted()
+                    
+                case .failure(let error):
+                    print("[GachaResultViewModel] Error: \(error.localizedDescription)")
+                    observer.onError(error)
+                }
+            }
+            
+            return Disposables.create()
+        }
+    }
+    
+    // MARK: - Getter
+    
+    /// drawnItemInfo 가져오기 (착용하기 API 호출 시 사용)
+    func getDrawnItemInfo() -> GachaResultSection? {
+        return drawnItemInfo
     }
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewModel/GachaResultViewModel.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/GachaResult/ViewModel/GachaResultViewModel.swift
@@ -29,12 +29,16 @@ final class GachaResultViewModel: BaseViewModel {
     // MARK: - Output
     
     struct Output {
-        
+        let itemType: BehaviorRelay<[String]>
     }
     
     // MARK: - Transform
     
     func transform(input: Input) -> Output {
-        return Output()
+        return Output(
+            itemType: BehaviorRelay(
+                value: itemType == .character ? ["캐릭터를", "캐릭터는"] : ["배경을", "배경은"]
+            )
+        )
     }
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewController/StoreViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewController/StoreViewController.swift
@@ -194,9 +194,10 @@ final class StoreViewController: BaseViewController {
 
         // 뽑기 머신 탭
         gachaMachine.rx.tap
-            .bind(with: self) { owner, _ in
+            .withLatestFrom(output.selectedTab)
+            .bind(with: self) { owner, itemType in
                 // TODO: 백그라운드에서 포인트를 받아와서(마이아이템 API 호출) 뽑기하기 버튼 누를 때 포인트 UI 업데이트
-                owner.presentGachaViewController()
+                owner.presentGachaViewController(itemType: itemType)
             }
             .disposed(by: disposeBag)
     }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewController/StoreViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewController/StoreViewController.swift
@@ -170,6 +170,14 @@ final class StoreViewController: BaseViewController {
         )
         let output = storeViewModel.transform(input: input)
         
+        // 아이템 유효기간 갱신 Notification 구독
+        NotificationCenter.default.rx
+            .notification(.itemValidPeriodRefresh)
+            .bind(with: self) { owner, _ in
+                owner.viewWillAppearTrigger.accept(())
+            }
+            .disposed(by: disposeBag)
+        
         // 아이템 데이터 바인딩
         output.items
             .observe(on: MainScheduler.instance)

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewModel/StoreViewModel.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/MyPage/Store/ViewModel/StoreViewModel.swift
@@ -147,11 +147,6 @@ final class StoreViewModel: BaseViewModel {
         }
     }
     
-    /// 아이템 유효기간 갱신
-    private func refreshItemsValidity(itemType: ItemType) -> Observable<[StoreSectionModel]> {
-        return fetchAllItems(itemType: itemType)
-    }
-    
     /// 아이템 착용
     private func patchItem(itemType: String, itemID: Int) -> Observable<Void> {
         return Observable.create { observer in


### PR DESCRIPTION
# 📌 이슈번호
- #148 

# 📌 구현/추가 사항
- [x] 뽑기 API 연동 및 뽑은 캐릭터/배경을 이미지뷰에 적용
- [x] 배경 탭을 누를 경우 배경 뽑기로 전환
- [x] 배경 탭이 선택된 상태에서 뽑기하기 누를 경우 배경 뽑기 구현
- [x] 캐릭터 50포인트, 배경은 100포인트
- [x] 뽑기 완료 후 상점 페이지로 이동 시 아이템 유효기간 갱신
- [x] 아이템 유효기간 표시 버그 수정