### PR TITLE
[Fix] 메뉴 상세페이지 좋아요 버튼 로직 수정

### DIFF
--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Common/UIViewController/Alert/AlertViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Common/UIViewController/Alert/AlertViewController.swift
@@ -33,17 +33,15 @@ final class AlertViewController: BaseViewController {
         $0.contentMode = .scaleAspectFit
     }
     
-    private let alertMessageLabel = PaddingLabel(
-        padding: UIEdgeInsets(top: 24, left: 23.5, bottom: 24, right: 23.5)
-    ).then {
-        $0.setLabelUI("", font: .pretendard_semibold, size: 15, color: .black)
+    private let alertMessageView = UIView().then {
         $0.setCornerRadius(radius: 10)
         $0.backgroundColor = .white
+    }
+    
+    private let alertMessageLabel = UILabel().then {
+        $0.setLabelUI("", font: .pretendard_semibold, size: 15, color: .black)
         $0.textAlignment = .center
         $0.numberOfLines = 0
-        
-        
-        $0.setBorder()
     }
     
     // MARK: - LifeCycle
@@ -71,9 +69,11 @@ final class AlertViewController: BaseViewController {
     override func setHierarchy() {
         [
             circleIconView,
-            alertMessageLabel,
+            alertMessageView,
             alertImageView
         ].forEach(view.addSubview)
+        
+        alertMessageView.addSubview(alertMessageLabel)
     }
     
     // MARK: - Set Constraints
@@ -91,10 +91,15 @@ final class AlertViewController: BaseViewController {
             $0.bottom.equalTo(circleIconView).inset(13)
         }
         
-        alertMessageLabel.snp.makeConstraints {
+        alertMessageView.snp.makeConstraints {
             $0.top.equalTo(circleIconView).offset(46)
             $0.horizontalEdges.equalToSuperview().inset(56)
             $0.centerX.equalToSuperview()
+        }
+        
+        alertMessageLabel.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(24)
+            $0.horizontalEdges.equalToSuperview().inset(23.5)
         }
     }
     

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Common/UIViewController/Alert/AlertViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Common/UIViewController/Alert/AlertViewController.swift
@@ -40,6 +40,10 @@ final class AlertViewController: BaseViewController {
         $0.setCornerRadius(radius: 10)
         $0.backgroundColor = .white
         $0.textAlignment = .center
+        $0.numberOfLines = 0
+        
+        
+        $0.setBorder()
     }
     
     // MARK: - LifeCycle

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewInfoView.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewInfoView.swift
@@ -18,6 +18,7 @@ final class MenuReviewInfoView: UIView {
     private var isOwned = false
     private var reviewLikedCount = 0
     var onLikeToggled: ((Bool) -> Void)?
+    var onShowOwnReviewAlert: (() -> Void)?
     
     // MARK: - UI Components
     
@@ -178,8 +179,7 @@ final class MenuReviewInfoView: UIView {
             }
             onLikeToggled?(isReviewLiked)
         } else {
-            // TODO: 실패 UI 띄우기
-            print("[MenuReviewInfoView] Error: 자기 리뷰 좋아요 안됨")
+            onShowOwnReviewAlert?()
         }
     }
 }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewInfoView.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewInfoView.swift
@@ -37,7 +37,7 @@ final class MenuReviewInfoView: UIView {
         $0.setLabelUI("", font: .pretendard, size: 13, color: .darkGray)
     }
     
-    private lazy var reviewLikeButton = UIButton().then {
+    lazy var reviewLikeButton = UIButton().then {
         $0.setImage(UIImage(named: "Like")?.resize(to: CGSize(width: 17, height: 17)), for: .normal)
         $0.addTarget(self, action: #selector(didTapReviewLikeButton), for: .touchUpInside)
     }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/View/MenuReviewListCell/MenuReviewListCell.swift
@@ -36,7 +36,6 @@ final class MenuReviewListCell: UICollectionViewCell, ReuseIdentifying {
         })
     }
     
-    // TODO: private 해제 방법 말고 다른 방법 없을까?
     let menuReviewInfoView = MenuReviewInfoView()
     
     private let reviewCommentTextView = UITextView().then {
@@ -334,6 +333,10 @@ extension MenuReviewListCell: UIGestureRecognizerDelegate {
         // 터치된 뷰가 reviewImageCollectionView의 subView라면 gesture 비활성화
         if let touchedView = touch.view,
            touchedView.isDescendant(of: reviewImageCollectionView) { return false }
+        
+        // 터치된 뷰가 reviewLikeButton이라면 gesture 비활성화
+        if let touchedView = touch.view,
+           touchedView.isDescendant(of: menuReviewInfoView.reviewLikeButton) { return false }
         
         return true
     }

--- a/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
+++ b/BJJ_iOS/BJJ_iOS/Source/Presentation/Tab/Home/MenuDetail/ViewController/MenuDetailViewController.swift
@@ -416,7 +416,7 @@ final class MenuDetailViewController: UIViewController {
                     }
                 }
             case .failure(let error):
-                print("<< [MenuDetailVC] 메뉴 좋아요 실패: \(error.localizedDescription)")
+                self.presentAlertViewController(alertType: .failure, title: error.localizedDescription)
             }
         }
     }
@@ -428,7 +428,7 @@ final class MenuDetailViewController: UIViewController {
                 self.isReviewLikedList[indexPath.item] = isLiked
                 
             case .failure(let error):
-                print("[MenuDetailVC] 리뷰 좋아요 실패: \(error.localizedDescription)")
+                self.presentAlertViewController(alertType: .failure, title: error.localizedDescription)
             }
             
         }
@@ -673,6 +673,16 @@ extension MenuDetailViewController: UICollectionViewDelegate, UICollectionViewDa
                 }
                 // 각 리뷰별 타이머 저장
                 self.reviewLikeDebounceTimers[indexPath.item] = timer
+            }
+            cell.menuReviewInfoView.onShowOwnReviewAlert = { [weak self] in
+                guard let self = self else { return }
+                
+                DispatchQueue.main.async {
+                    self.presentAlertViewController(
+                        alertType: .failure,
+                        title: "자신의 리뷰에는 좋아요를 누를 수 없습니다."
+                    )
+                }
             }
             
             return cell


### PR DESCRIPTION
# 📌 이슈번호
- #197 

# 📌 구현/추가 사항
- [x] cell 전체 탭과 좋아요 버튼 탭 구분
- [x] alertVC 수정
- [x] 자신의 리뷰에 좋아요 방지 alertVC 띄움